### PR TITLE
模块作用域加入Gboard

### DIFF
--- a/hook/src/main/res/values/strings-notran.xml
+++ b/hook/src/main/res/values/strings-notran.xml
@@ -3,5 +3,6 @@
     <string-array name="xposed_scope">
         <item>cc.aoeiuv020.iamnotdisabled</item>
         <item>com.android.chrome</item>
+        <item>com.google.android.inputmethod.latin</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Gboard在检测到无障碍功能开启时，不能自定义工具栏